### PR TITLE
Update README to account for Solidity 0.8.0

### DIFF
--- a/integer_overflow/README.md
+++ b/integer_overflow/README.md
@@ -1,6 +1,6 @@
 # Integer Overflow
 
-It is possible to cause `add` and `sub` to overflow (or underflow) on any type of integer in Solidity.  
+Prior to Solidity version 0.8.0, it is possible to cause `add` and `sub` to overflow (or underflow) any type of integer.  
 
 ## Attack Scenarios
 


### PR DESCRIPTION
https://github.com/crytic/not-so-smart-contracts/issues/40#issue-1139870557 closing this issue. The README now lets the reader know that this problem is only in older compiler versions.